### PR TITLE
version: latest does not actually retrieve the latest version

### DIFF
--- a/phpcs-action.bash
+++ b/phpcs-action.bash
@@ -5,7 +5,7 @@ docker_tag=$(cat ./docker_tag)
 
 if [ -z "$ACTION_PHPCS_PATH" ]
 then
-	phar_url="https://www.getrelease.download/squizlabs/PHP_CodeSniffer/$ACTION_VERSION/phpcs.phar"
+	phar_url="https://www.getrelease.download/PHPCSStandards/PHP_CodeSniffer/$ACTION_VERSION/phpcs.phar"
 	phar_path="${github_action_path}/phpcs.phar"
 	curl --silent -H "User-agent: cURL (https://github.com/php-actions)" -L "$phar_url" > "$phar_path"
 else


### PR DESCRIPTION
When `version` is set to `latest` (or not specified and falls back to [its default value](https://github.com/php-actions/phpcs/blob/dfdd77a6edfc6d0d0f194bdf0c934c8d841ea2fa/action.yml#L7)) it fetches the phar from the following URL:

https://github.com/php-actions/phpcs/blob/dfdd77a6edfc6d0d0f194bdf0c934c8d841ea2fa/phpcs-action.bash#L8

The code behind that [automagically maps](https://github.com/g105b/getrelease.download/blob/master/index.php#L76) the highest semver number to latest.  The list of available versions is [seeded from the repo's tags](https://github.com/g105b/getrelease.download/blob/master/index.php#L43).

Due to [reasons](https://github.com/squizlabs/PHP_CodeSniffer/issues/3932) development of `squizlabs/php_codesniffer` has moved from https://github.com/squizlabs/PHP_CodeSniffer to https://github.com/PHPCSStandards/PHP_CodeSniffer

The newest tag available in the squizlabs repo is 3.7.2.  The newest version available [on Packagist](https://packagist.org/packages/squizlabs/php_codesniffer) as of this writing is 3.9.1.  All versions after 3.7.2 were [tagged](https://github.com/PHPCSStandards/PHP_CodeSniffer/tags) in the PHPCSStandards org.  Therefore, **this PR moves the pulling of phar files from the `squizlabs` repo to the `PHPCSStandards` repo.**

Long term the proper solution would be to [get this data from packagist](https://packagist.org/apidoc#get-package-data#get-package-data) and the only reason I didn't open a PR for that is the output does not offer a direct link to a phar.  Note also that this particular package is (confusingly) defined as a [virtual package](https://alanastorm.com/composer-virtual-packages/) as well.