### PR TITLE
Add `ignore_warnings_on_exit` and `ignore_errors_on_exit` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The following configuration options are available:
 + `severity` - The minimum severity required to display an error or warning
 + `error_severity` - The minimum severity required to display an error
 + `warning_severity` - The minimum severity required to display a warning
++ `ignore_warnings_on_exit` - Exit with a zero error code despite the presence of warnings (1 = true, default 0 = false).
++ `ignore_errors_on_exit` - xit with a zero error code despite the presence of errors (1 = true, default 0 = false).
 + `args` - Extra arguments to pass to the phpcs binary
 
 If you require other configurations of PHPMD, please request them in the [Github issue tracker].

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,14 @@ inputs:
     description: The minimum severity required to display a warning
     required: false
 
+  ignore_warnings_on_exit:
+    desctiption: Exit with a zero error code despite the presence of warnings (1 = true, default 0 = false).
+    required: false
+
+  ignore_errors_on_exit:
+    description: Exit with a zero error code despite the presence of errors (1 = true, default 0 = false).
+    required: false
+
   args:
     description: Extra arguments to pass to the phpcs binary
     required: false

--- a/action.yml
+++ b/action.yml
@@ -82,11 +82,11 @@ inputs:
     required: false
 
   ignore_warnings_on_exit:
-    desctiption: Exit with a zero error code despite the presence of warnings (1 = true, default 0 = false).
+    description: Exit with a zero error code despite the presence of warnings
     required: false
 
   ignore_errors_on_exit:
-    description: Exit with a zero error code despite the presence of errors (1 = true, default 0 = false).
+    description: Exit with a zero error code despite the presence of errors
     required: false
 
   args:
@@ -117,6 +117,8 @@ runs:
         ACTION_SEVERITY: ${{ inputs.severity }}
         ACTION_ERROR_SEVERITY: ${{ inputs.error_severity }}
         ACTION_WARNING_SEVERITY: ${{ inputs.warning_severity }}
+        ACTION_IGNORE_WARNINGS_ON_EXIT: ${{ inputs.ignore_warnings_on_exit }}
+        ACTION_IGNORE_ERRORS_ON_EXIT: ${{ inputs.ignore_errors_on_exit }}
         ACTION_ARGS: ${{ inputs.args }}
 
       id: phpcs_run

--- a/phpcs-action.bash
+++ b/phpcs-action.bash
@@ -95,6 +95,16 @@ then
 	command_string+=(--warning-severity="$ACTION_WARNING_SEVERITY")
 fi
 
+if [ -n "$ACTION_IGNORE_WARNINGS_ON_EXIT" ]
+then
+	command_string+=(--runtime-set ignore_warnings_on_exit "$ACTION_IGNORE_WARNINGS_ON_EXIT")
+fi
+
+if [ -n "$ACTION_IGNORE_ERRORS_ON_EXIT" ]
+then
+	command_string+=(--runtime-set ignore_errors_on_exit "$ACTION_IGNORE_ERRORS_ON_EXIT")
+fi
+
 if [ -n "$ACTION_ARGS" ]
 then
 	command_string+=($ACTION_ARGS)

--- a/phpcs-action.bash
+++ b/phpcs-action.bash
@@ -97,11 +97,21 @@ fi
 
 if [ -n "$ACTION_IGNORE_WARNINGS_ON_EXIT" ]
 then
-	command_string+=(--runtime-set ignore_warnings_on_exit "$ACTION_IGNORE_WARNINGS_ON_EXIT")
+	case "$ACTION_IGNORE_WARNINGS_ON_EXIT" in
+		'true'|'1') normalised_value=1 ;;
+		'false'|'0') normalised_value=0 ;;
+		*) normalised_value=0 ;;
+	esac
+	command_string+=(--runtime-set ignore_warnings_on_exit "$normalised_value")
 fi
 
 if [ -n "$ACTION_IGNORE_ERRORS_ON_EXIT" ]
 then
+	case "$ACTION_IGNORE_ERRORS_ON_EXIT" in
+		'true'|'1') normalised_value=1 ;;
+		'false'|'0') normalised_value=0 ;;
+		*) normalised_value=0 ;;
+	esac
 	command_string+=(--runtime-set ignore_errors_on_exit "$ACTION_IGNORE_ERRORS_ON_EXIT")
 fi
 


### PR DESCRIPTION
Add parameters `ignore_warnings_on_exit` and `ignore_errors_on_exit` to avoid a non-zero error code in the presence of warnings or errors respectively (see https://github.com/php-actions/phpcs/issues/2).