### PR TITLE
fix: only attempt to set executable if not

### DIFF
--- a/phpcs-action.bash
+++ b/phpcs-action.bash
@@ -12,7 +12,9 @@ else
 	phar_path="${GITHUB_WORKSPACE}/$ACTION_PHPCS_PATH"
 fi
 
-chmod +x $phar_path
+if ! [ -x "$phar_path" ]; then
+    chmod +x $phar_path
+fi
 command_string=("phpcs")
 
 if [ -n "$ACTION_PATH" ]


### PR DESCRIPTION
It seems the previous composer path is not writable by phpcs so this change will only attempt to set the executable flag if it isn't already. Under normal circumstances composer will set this.